### PR TITLE
Create cheat_sheet.ipynb

### DIFF
--- a/bhsa/cheat_sheet.ipynb
+++ b/bhsa/cheat_sheet.ipynb
@@ -1,0 +1,1139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# tf.cheatsheet: A. and N. F. E. L. T. S. C. \n",
+    "## [Online source](https://annotation.github.io/text-fabric/tf/cheatsheet.html#s-search-low-level)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tf.app import use\n",
+    "import os\n",
+    "import collections\n",
+    "from itertools import chain\n",
+    "\n",
+    "A = use('bhsa', hoist=globals())\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A. Advanced API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.showContext(...)`\n",
+    "\n",
+    "Show app settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.showContext(...) // Show App Settings:\n",
+    "# For each key passed to this function, the information for that key \n",
+    "# will be displayed. If no keys are passed, all keys will be displayed.\n",
+    "A.showContext('features')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.header()`\n",
+    "\n",
+    "Show colofon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show colofon, a.k.a, the publishing information. \n",
+    "A.header()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.webLink(n, ...)`\n",
+    "\n",
+    "Hyperlink to node n on the web."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.webLink(n, ...) // Hyperlink to node n on the web.\n",
+    "A.webLink(500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.dm(markdownString)`\n",
+    "\n",
+    "Display markdown string in notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.dm(markdownString) // Display markdown string in notebook.\n",
+    "n = 200\n",
+    "A.dm(f\"**Node value** = `{n}`\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.dh(htmlString)`\n",
+    "\n",
+    "Display HTML string in notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.dh(htmlString) // Display HTML string in notebook.\n",
+    "n = 500\n",
+    "A.dh(f\"<h2>Node value</h2><b>{n}</b>\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Display methods\n",
+    "\n",
+    ">A.method(option1=value1, option2=value2, ...)\n",
+    "\n",
+    "See [options and values](https://annotation.github.io/text-fabric/tf/advanced/options.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.displayShow(...)`\n",
+    "\n",
+    "Show display options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.displayShow(...) // No args for all display options. \n",
+    "A.displayShow('skipCols', 'withPassage')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.displaySetup(...)`\n",
+    "\n",
+    "Set up display options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.displaySetup(...) // Set up your display options.\n",
+    "A.displaySetup(skipCols='1 2 3', withPassage=True)\n",
+    "A.displayShow('skipCols', 'withPassage')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.displayReset(...)`\n",
+    "\n",
+    "Reset display options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.displayReset(...) // No args to reset everything.\n",
+    "A.displayReset('skipCols')\n",
+    "A.displayShow('skipCols', 'withPassage')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.table(results, ...)`\n",
+    "\n",
+    "Plain rendering of tuple of tuples of node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.table(results, ...) // Plain rendering of tuple of tuples of node\n",
+    "words = ( (1, 2, 3), (4, 5, 6), (7, 8, 9, 10), (6866, 5867, 5868))\n",
+    "A.table(words, fmt='text-orig-plain')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.plainTuple(tup, ith, ...)`\n",
+    "\n",
+    "Plain rendering of tuple of node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.plainTuple(tup, seq, ...) // Display plain text of a tuple of nodes.\n",
+    "A.plainTuple(words[0], 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.plain(node, ...)`\n",
+    "\n",
+    "Plain rendering of node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.plain(node, ...) // Plain rendering of node.\n",
+    "A.plain(2, withPassage=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.show(results, ...)`\n",
+    "\n",
+    "Pretty rendering of tuple of tuples of node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.show(results, ...) // Pretty rendering of tuple of tuples of node.\n",
+    "A.show(words)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.prettyTuple(tup, ith, ...)`\n",
+    "\n",
+    "Pretty rendering of tuple of node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.prettyTuple(tup, seq, ...) // Pretty rendering of tuple of node.\n",
+    "A.prettyTuple(words[0], 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.pretty(node, ...)`\n",
+    "\n",
+    "Pretty rendering of node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.pretty(node, ...) // Pretty rendering of node. \n",
+    "A.pretty(2, showGraphics=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.unravel(node, ...)`\n",
+    "\n",
+    "Convert a graph to a tree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A.unravel(node, ...) // Convert a graph to a tree.\n",
+    "A.unravel(65048)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.search(...)`\n",
+    "\n",
+    "Search, collect and deliver results, report number of results.\n",
+    "\n",
+    ">def search(app, query, silent=False, sets=None,\\\n",
+    "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shallow=False, sort=True)\n",
+    "\n",
+    "**query** : [dict](https://annotation.github.io/text-fabric/tf/about/searchusage.html)\\\n",
+    "the search template (tf.about.searchusage) that has to be searched for.\n",
+    "\n",
+    "**silent** : boolean, optional False\\\n",
+    "if True it will suppress the reporting of the number of results.\n",
+    "\n",
+    "**shallow** : boolean, optional False\\\n",
+    "If True or 1, the result is a set of things that match the top-level element of the query.\n",
+    "\n",
+    "If 2 or a bigger number n, return the set of truncated result tuples: only the first n members of each tuple are retained.\n",
+    "\n",
+    "If False or 0, a list of all result tuples will be returned.\n",
+    "\n",
+    "**sets** : dict, optional None\\\n",
+    "If not None, it should be a dictionary of sets, keyed by a names. In query you can refer to those names to invoke those sets.\n",
+    "\n",
+    "For example, if you have a set gappedPhrases of all phrase nodes that have a gap, you can pass sets=dict(gphrase=gappedPhrases), and then in your query you can say\n",
+    ">gphrase function=Predword sp=verb etc.\n",
+    "\n",
+    "This is handy when you need node sets that cannot be conveniently queried. You can produce them by hand-coding. Once you got them, you can use them over and over again in queries. Or you can save them with writeSets() and use them in the TF browser.\n",
+    "\n",
+    "**sort** : boolean, optional True\\\n",
+    "If True (default), search results will be returned in canonical order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Morphology: https://etcbc.github.io/bhsa/features/0_home/\n",
+    "\"\"\"\n",
+    "| NAME:\t        | DESCRIPTION:\t    | EXAMPLES:\n",
+    "| gn prs_gn     | gender\t        | m f\n",
+    "| nu prs_nu     | number\t        | sg pl du\n",
+    "| ps prs_ps     | person\t        | p1 p2 p3\n",
+    "| st\t        | state\t            | a c e\n",
+    "| vs\t        | verbal stem\t    | qal piel nif hif\n",
+    "| vt\t        | verbal tense      | perf impf wayq\n",
+    "| sp\t        | part of speech    | verb subs\n",
+    "| pdp\t        | phrase dependent  | verb subs\n",
+    "                | part of speech\t|\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find word combinations within a sentence within chapter 2 of either Genesis \n",
+    "# or Exodus, where one of the words is a verb and the other is a noun.\n",
+    "query = \"\"\"\n",
+    "book book=Genesis|Exodus\n",
+    "   chapter chapter=2\n",
+    "      sentence\n",
+    "        word sp=verb nu=pl\n",
+    "        word sp=subs gn=f nu=sg\n",
+    "\"\"\"\n",
+    "\n",
+    "# A.search(...) // Search, collect and deliver results, report number of results.\n",
+    "results = A.search(query)\n",
+    "\n",
+    "A.table(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## N. Nodes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `N.walk()`\n",
+    "\n",
+    "Generator of all nodes in canonical ordering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generator of all nodes in canonical ordering.\n",
+    "N.walk()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `N.sortNodes(nodes)`\n",
+    "\n",
+    "Sorts nodes in the canonical ordering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# N.sortNodes(nodes) // Sorts nodes in canonical ordering.\n",
+    "N.sortNodes((5, 3, 7, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `N.otypeRank[nodeType]`\n",
+    "\n",
+    "Ranking position of nodeType."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# N.otypeRank[nodeType] // Ranking position of nodeType.\n",
+    "# Use just N.otypeRank for the whole dictionary. \n",
+    "N.otypeRank['sentence'] "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `N.sortKey(node)`\n",
+    "\n",
+    "Defines the canonical ordering on nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# N.sortKey(node) // Defines the canonical ordering on nodes.\n",
+    "N.sortKey(685055)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## F. Node Features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `Fall()`\n",
+    "\n",
+    "All loaded feature names (node features only)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All loaded feature names.\n",
+    "Fall()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `F.fff.v(node)`\n",
+    "\n",
+    "Get value of node feature fff."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# F.fff.v(node) // Get value of node feature fff.\n",
+    "n = 3\n",
+    "A.pretty(n)\n",
+    "F.rank_lex.v(n)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `F.fff.s(value)`\n",
+    "\n",
+    "Get nodes where feature fff has value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# F.fff.s(value) // Get nodes where feature fff has value.\n",
+    "F.rank_lex.s(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "memorial = []\n",
+    "for word in F.otype.s('word'):\n",
+    "    if F.g_cons_utf8.v(word) == 'זכרון':\n",
+    "        memorial.append(word)\n",
+    "\n",
+    "F.lex.v(memorial[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `F.fff.freqList(...)`\n",
+    "\n",
+    "Frequency list of values of fff."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# F.fff.freqList(...) // Frequency list of values of fff. \n",
+    "# If you pass a set of nodeTypes, only the values for nodes within those types will be counted.\n",
+    "F.typ.freqList(nodeTypes='phrase')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `F.fff.items(...)`\n",
+    "\n",
+    "Generator of all entries of fff as mapping from nodes to values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# F.fff.items() // Generates all entries of fff as mapping from nodes to values.\n",
+    "F.lex.items()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `F.fff.meta`\n",
+    "\n",
+    "Meta data of feature fff."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# F.fff.meta // Meta data of feature fff.\n",
+    "F.freq_lex.meta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Special node feature *otype*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `F.otype.v(node)`\n",
+    "\n",
+    "Get type of node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# F.otype.v(node) // Get type of node.\n",
+    "F.otype.v(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `F.otype.s(nodeType)`\n",
+    "\n",
+    "Get all nodes of type nodeType."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# F.otype.s(nodeType) // Get all nodes of type nodeType.\n",
+    "F.otype.s('verse')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `F.otype.sInterval(nodeType)`\n",
+    "\n",
+    "Gives start and ending nodes of nodeType."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# F.otype.sInterval(nodeType) // Gives start and ending nodes of nodeType.\n",
+    "F.otype.sInterval('phrase')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `A.otype.{maxSlot, maxNode, slotType, all}`\n",
+    "\n",
+    "The last slot node; Last node; Slot type; Sorted list of all node types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The last slot node.\n",
+    "a = F.otype.maxSlot\n",
+    "\n",
+    "# The last node. \n",
+    "b = F.otype.maxNode\n",
+    "\n",
+    "# The slot type. \n",
+    "c = F.otype.slotType\n",
+    "\n",
+    "# Sorted list of all node types. \n",
+    "d = F.otype.all \n",
+    "\n",
+    "print(f\"maxSlot: {a}\\nmaxNode: {b}\\nslotType: {c}\\nallTypes: {d}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## E. Edge Features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `Eall()`\n",
+    "\n",
+    "All loaded feature names (edge features only)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All loaded (edge) feature names.\n",
+    "Eall()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `E.fff.f(node)`\n",
+    "\n",
+    "Get value of feature fff for edges from node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# E.fff.f(node) // Get value of feature fff for edges from node.\n",
+    "E.mother.f(427567)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `E.fff.t(node)`\n",
+    "\n",
+    "Get value of feature fff for edges to node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# E.fff.t(node) // Get value of feature fff for edges to node.\n",
+    "E.mother.t(427566)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `E.fff.freqList(...)`\n",
+    "\n",
+    "Frequency list of values of fff."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# E.fff.freqList() // Frequency list of values of fff.\n",
+    "E.crossref.freqList()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `E.fff.items(...)`\n",
+    "\n",
+    "Generator of all entries of fff as mapping from edges to values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# E.fff.items() // Generator of all entries of fff as mapping from edges to values.\n",
+    "E.crossref.items()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `E.fff.b(node)`\n",
+    "\n",
+    "Get value of feature fff for edges from and to node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# E.fff.b(node) // Get value of feature fff for edges from and to node.\n",
+    "E.crossref.b(1414401)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `E.oslots.s(node)`\n",
+    "\n",
+    "Set of slots linked to node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# E.oslots.s(node) // Set of slots linked to node.\n",
+    "E.oslots.s(1414401)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## L. Locality"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `L.i(node, otype=...)`\n",
+    "\n",
+    "Go to intersecting nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# L.i(node, otype=...) // Go to intersecting nodes.\n",
+    "L.i(1414401, otype='phrase')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `L.u(node, otype=...)`\n",
+    "\n",
+    "Go one level up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# L.u(node, otype=...) // Go one level up.\n",
+    "up = L.u(1, otype='sentence')\n",
+    "for i in up:\n",
+    "    print(i, F.otype.v(i))\n",
+    "    A.plain(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `L.d(node, otype=...)`\n",
+    "\n",
+    "Go one level down."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# L.d(node, otype=...) // Go one level down.\n",
+    "ld = L.d(651723)\n",
+    "for i in ld:\n",
+    "    print(i, F.otype.v(i))\n",
+    "    A.plain(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `L.p(node, otype=...)`\n",
+    "\n",
+    "Go to adjacent previous nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# L.p(node, otype=...) // Go to adjacent previous nodes.\n",
+    "lp = L.p(651723)\n",
+    "for i in lp:\n",
+    "    print(i, F.otype.v(i))\n",
+    "    A.plain(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `L.n(node, otype=...)`\n",
+    "\n",
+    "Go to adjacent next nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# L.n(node, otype=...) // Go to adjacent next nodes.\n",
+    "ln = L.n(651723)\n",
+    "for i in ln:\n",
+    "    print(i, F.otype.v(i))\n",
+    "    A.plain(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## T. Text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `T.text(node, fmt=..., ...)`\n",
+    "\n",
+    "Give formatted text associated with node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# T.text(node, fmt=..., ...) // Give formatted text associated with node.\n",
+    "t = T.text(range(1,5), fmt='text-orig-plain', descend=True, explain=False)\n",
+    "for i in t.split():\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## S. Search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `S.search(query, limit=None)`\n",
+    "\n",
+    "Query the TF dataset with a template."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"\"\"\n",
+    "book book=Genesis|Exodus\n",
+    "   chapter chapter=2\n",
+    "\"\"\"\n",
+    "\n",
+    "# S.search(query, limit=None) // Query the TF dataset with a template.\n",
+    "result = S.search(query, shallow=False)\n",
+    "\n",
+    "A.show(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `S.{study(query), showPlan()}`\n",
+    "\n",
+    "Study the query to set up a plan; Show search plan from the last study."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# S.study(query, ...) // Study the query in order to set up a plan.\n",
+    "S.study(query)\n",
+    "\n",
+    "# S.showPlan(details=False) // Show the search plan resulting from the last study.\n",
+    "S.showPlan()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `S.relationsLegend()`\n",
+    "\n",
+    "Catalog of all relational devices in search templates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Catalog of all relational devices in search templates.\n",
+    "S.relationsLegend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `S.{count(), fetch(), glean(tup)}`\n",
+    "\n",
+    "Count results; Fetch results; Render a single result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# S.count(progress=None, limit=None) // Count the results, up to a limit. \n",
+    "S.count()\n",
+    "\n",
+    "# S.fetch(limit=None, ...) // Fetches the results, up to a limit.\n",
+    "S.fetch()\n",
+    "\n",
+    "# S.glean(tup) // Renders a single result into something human readable.\n",
+    "S.glean((1, 2, 3))"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "7812ea015bdcee6f23a998adcdd2ef97c151c0c241b7b7070987d9313e41299d"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.5 64-bit",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
A Jupyter notebook to test the methods from the tf.cheatsheet (https://annotation.github.io/text-fabric/tf/cheatsheet.html).

It includes most of the methods from A, N, F, E, L, T, and S, with MD headings for each and code cells to test them out.